### PR TITLE
fix: direct PR notifications

### DIFF
--- a/src/app/prmojiApp.ts
+++ b/src/app/prmojiApp.ts
@@ -7,12 +7,11 @@ import SlackClient from "../slack/client.ts";
 import { PostgresStorage } from "../storage/postgres.ts";
 import {
   formatEventList,
+  getDirectNotificationMessage,
   getMessage,
   getPrUrlsFromString,
   shouldAddEmoji,
   shouldNotify,
-  getDirectNotificationMessage,
-getPrSender,
 } from "../utils/helpers.ts";
 import {
   APP_NAME,
@@ -117,10 +116,14 @@ export class PrmojiApp {
         logger.info(
           "[app] Event meets notification criteria, sending message.",
         );
-        await this.slackClient.sendMessage(
-          getMessage(event),
-          this.notificationsChannelId,
-        );
+        try {
+          await this.slackClient.sendMessage(
+            getMessage(event),
+            this.notificationsChannelId,
+          );
+        } catch (e) {
+          logger.error("[app] Error sending message:", e);
+        }
       } else {
         logger.info(
           "[app] Event does not meet notification criteria, not sending message",

--- a/src/models/GithubRequestBody.ts
+++ b/src/models/GithubRequestBody.ts
@@ -45,5 +45,5 @@ export default interface GithubRequestBody {
   };
   sender?: {
     login: string;
-  }
+  };
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -204,7 +204,7 @@ export function getDirectNotificationMessage(event: GithubEvent) {
   const sender = event.sender || "(missing sender)";
   const prUrl = event.url || "(missing PR URL)";
   const action = event.action || "(missing action)";
-  
+
   switch (action) {
     case Actions.CREATED:
       return `${sender} created <${prUrl}| PR> :heavy_plus_sign:`;

--- a/src/utils/requestParsers.ts
+++ b/src/utils/requestParsers.ts
@@ -21,9 +21,9 @@ import {
   getPrNumber,
   getPrRepoFullName,
   getPrRepoName,
+  getPrSender,
   getPrTitle,
   getPrUrl,
-  getPrSender,
 } from "./helpers.ts";
 import * as logger from "../utils/logger.ts";
 


### PR DESCRIPTION
don't crash on misconfigured notification channel id