### PR TITLE
chore: change logging for pr event handling

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -67,7 +67,7 @@ export class PrmojiApp {
   }
 
   async handlePrEvent(event: GithubEvent) {
-    info("received PR event:", event.number || "(no PR number)");
+    info("received PR event:", event.action, event.number);
 
     if (!event.url || !event.action) {
       debug("missing field(s), discarding PR event");

--- a/deno.lock
+++ b/deno.lock
@@ -217,6 +217,7 @@
     "https://deno.land/std@0.193.0/streams/zip_readable_streams.ts": "a9d81aa451240f79230add674809dbee038d93aabe286e2d9671e66591fc86ca",
     "https://deno.land/std@0.196.0/async/delay.ts": "a6142eb44cdd856b645086af2b811b1fcce08ec06bb7d50969e6a872ee9b8659",
     "https://deno.land/std@0.196.0/fmt/colors.ts": "a7eecffdf3d1d54db890723b303847b6e0a1ab4b528ba6958b8f2e754cf1b3bc",
+    "https://deno.land/std@0.196.0/fmt/printf.ts": "d3cf1bcc6af4d1ab04747a99f22845abfd0c7ec3cfcc72cfc2b544128a821a12",
     "https://deno.land/std@0.99.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
     "https://deno.land/std@0.99.0/_util/os.ts": "e282950a0eaa96760c0cf11e7463e66babd15ec9157d4c9ed49cc0925686f6a7",
     "https://deno.land/std@0.99.0/path/_constants.ts": "1247fee4a79b70c89f23499691ef169b41b6ccf01887a0abd131009c5581b853",


### PR DESCRIPTION
This pr description is to test the release checklist validation feature.

## Release checklist

- [x] QA done on dev or purda (involving other colleagues if needed)
- [x] Support is notified about the upcoming change (if needed, e.g. user-facing)
- [x] [Changelog document](https://www.notion.so/colossyan/Changelog-ccf1eb69696a4a89b22138f3579538c2?pvs=4) updated (if needed, e.g. not chore)
- [x] Deployed to prod
- [x] Sentry & Grafana error rates monitored for at least 30 mins
- [x] Probably no crycat here, we're done