### PR TITLE
refactor: use pr url rx from consts

### DIFF
--- a/const.ts
+++ b/const.ts
@@ -6,7 +6,7 @@ export const NOTIFICATIONS_CHANNEL_ID = Deno.env.get(
 );
 
 export const RX_PR_URL =
-  /https:\/\/github.com\/([\w-]+)\/([\w-]+)\/pull\/(\d+)/;
+  /https:\/\/github.com\/([\w-]+)\/([\w-]+)\/pull\/(\d+)/g;
 
 export const RELEASE_CHECKLIST_HEADING = "## Release checklist";
 export const PR_VALIDATION_USER_NOTIFICATION_DELAY = 30 * 60 * 1000;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -8,6 +8,7 @@ import {
   IGNORED_COMMENTERS,
   MERGE_NOTIFICATION_MESSAGE,
   PR_ACTION_USER_NOTIFICATION_MESSAGES,
+  RX_PR_URL,
 } from "../const.ts";
 
 export function getPrUrl(requestBody: GithubRequestBody) {
@@ -116,9 +117,7 @@ export const actionConditions: ActionConditions = {
 };
 
 export function getPrUrlsFromString(text: string) {
-  return (
-    text.match(/(https:\/\/github\.com\/[\w-_]+\/[\w-_]+\/pull\/\d+)/g) ?? []
-  );
+  return text.match(RX_PR_URL) ?? [];
 }
 
 export function shouldAddEmoji(event: GithubEvent) {


### PR DESCRIPTION
This pr description is to test the release checklist validation feature.

## Release checklist

- [x] QA done on dev or purda (involving other colleagues if needed)
- [x] Support is notified about the upcoming change (if needed, e.g. user-facing)
- [x] [Changelog document](https://www.notion.so/colossyan/Changelog-ccf1eb69696a4a89b22138f3579538c2?pvs=4) updated (if needed, e.g. not chore)
- [x] Deployed to prod
- [x] Sentry & Grafana error rates monitored for at least 30 mins
- [x] Probably no crycat here, we're done